### PR TITLE
Support Multiline Indentation on Chrome and Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     hljs.highlightBlock(editor)
   }
 
-  const jar = CodeJar(editor, withLineNumbers(highlight))
+  const jar = CodeJar(editor, withLineNumbers(highlight), {multilineIndentation: true, tab: '  '})
 
   jar.updateCode(localStorage.getItem('code'))
   jar.onUpdate(code => {


### PR DESCRIPTION
Originally from: https://github.com/antonmedv/codejar/pull/100

This PR partially addresses https://github.com/antonmedv/codejar/issues/97 by providing opt-in support for multiline indentation in non-Firefox browsers.

By default, the current behavior (and codepaths) are the same as before. To opt-in to the new feature, users must enable a new option (`multilineIndentation`), as demonstrated in the updated `Index.html`

```
  const jar = CodeJar(editor, withLineNumbers(highlight), {multilineIndentation: true, tab: '  '})
```

I believe it would be possible to support Firefox, and I'm happy to collaborate with someone on this PR if they'd like to see support added for that initially.