### PR TITLE
Support for RTL Line Numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,18 +35,20 @@
             line-height: 20px;
             padding: 10px;
             tab-size: 4;
+            margin-top: 20px;
         }
     </style>
 </head>
 <body>
 <main>
-    <div class="editor language-js"></div>
+    <div id="editor" class="editor language-js"></div>
+    <div id="editor-rtl" class="editor language-js" dir="rtl"></div>
 </main>
 <script type="module">
   import {CodeJar} from './dist/codejar.js'
   import {withLineNumbers} from './dist/linenumbers.js'
 
-  const editor = document.querySelector('.editor')
+  const editor = document.querySelector('#editor')
 
   const highlight = editor => {
     // highlight.js does not trim old tags,
@@ -61,6 +63,25 @@
   jar.onUpdate(code => {
     localStorage.setItem('code', code)
   })
+
+  // Setup the RTL Demo:
+  const editorRtl = document.querySelector('#editor-rtl')
+  const jarRtl = CodeJar(editorRtl, withLineNumbers(highlight, { side: "right" }))
+
+  const rtlDemoCode = localStorage.getItem('code-rtl') || `لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار
+النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك
+السعادة البشرية، فلا أحد يرفض أو يكره
+أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين
+لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر
+عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر
+بأنه لا يوجد من يرغب في الحب ونيل المنال
+ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما
+قد تكمن السعاده فيما نتحمله من كد وأسي.`
+  jarRtl.updateCode(rtlDemoCode)
+  jarRtl.onUpdate(code => {
+    localStorage.setItem('code-rtl', code)
+  })
+
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js"></script>
 </body>

--- a/linenumbers.ts
+++ b/linenumbers.ts
@@ -4,6 +4,7 @@ type Options = {
   width: string
   backgroundColor: string
   color: string
+  side: "left" | "right"
 }
 
 export function withLineNumbers(
@@ -14,6 +15,7 @@ export function withLineNumbers(
     class: "codejar-linenumbers",
     wrapClass: "codejar-wrap",
     width: "35px",
+    side: "left",
     backgroundColor: "rgba(128, 128, 128, 0.15)",
     color: "",
     ...options
@@ -49,12 +51,17 @@ function init(editor: HTMLElement, opts: Options): HTMLElement {
 
   const gutter = document.createElement("div")
   gutter.className = opts.class
+  gutter.dir = opts.side == "left" ? "ltr" : "rtl"
   wrap.appendChild(gutter)
 
   // Add own styles
   gutter.style.position = "absolute"
   gutter.style.top = "0px"
-  gutter.style.left = "0px"
+  if (opts.side == "left") {
+    gutter.style.left = "0px"
+  } else {
+    gutter.style.right = "0px"
+  }
   gutter.style.bottom = "0px"
   gutter.style.width = opts.width
   gutter.style.overflow = "hidden"
@@ -67,9 +74,15 @@ function init(editor: HTMLElement, opts: Options): HTMLElement {
   gutter.style.fontSize = css.fontSize
   gutter.style.lineHeight = css.lineHeight
   gutter.style.paddingTop = css.paddingTop
-  gutter.style.paddingLeft = css.paddingLeft
-  gutter.style.borderTopLeftRadius = css.borderTopLeftRadius
-  gutter.style.borderBottomLeftRadius = css.borderBottomLeftRadius
+  if (opts.side == "left") {
+    gutter.style.paddingLeft = css.paddingLeft
+    gutter.style.borderTopLeftRadius = css.borderTopLeftRadius
+    gutter.style.borderBottomLeftRadius = css.borderBottomLeftRadius
+  } else {
+    gutter.style.paddingRight = css.paddingRight
+    gutter.style.borderTopRightRadius = css.borderTopRightRadius
+    gutter.style.borderBottomRightRadius = css.borderBottomRightRadius
+  }
 
   // Add line numbers
   const lineNumbers = document.createElement("div");
@@ -78,8 +91,12 @@ function init(editor: HTMLElement, opts: Options): HTMLElement {
   gutter.appendChild(lineNumbers)
 
   // Tweak editor styles
-  editor.style.paddingLeft = `calc(${opts.width} + ${gutter.style.paddingLeft})`
   editor.style.whiteSpace = "pre"
+  if (opts.side == "left") {
+    editor.style.paddingLeft = `calc(${opts.width} + ${gutter.style.paddingLeft})`
+  } else {
+    editor.style.paddingRight = `calc(${opts.width} + ${gutter.style.paddingRight})`
+  }
 
   // Swap editor with a wrap
   editor.parentNode!.insertBefore(wrap, editor)


### PR DESCRIPTION
Originally from: https://github.com/antonmedv/codejar/pull/101

This PR adds support for RTL line numbers via a new option (`side`) whose value may be either `left` or `right`.

When the option is set to `left` (or left un-set as `left` is the default), everything works as before. When the option is set to `right`, the line numbers are moved to the right hand side of the editor, and the `dir` attribute is set to `rtl`. 

A new demo has been added to the test page, as seen here:

<img width="825" alt="image" src="https://github.com/antonmedv/codejar/assets/484872/7a9401a8-ac2f-4a1f-9bcd-7a4367dd8c74">

The Arabic text in the demo page exists because many people will likely not be able to easily generate text of sufficient length to properly test the component easily. It is [Arabic Lorem Ipsum](https://ar.lipsum.com/).